### PR TITLE
🚑 Fix problem on dependabot file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,3 @@
----
 version: 2
 updates:
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Proposed Changes
<!--
Describe the changes that your pull request will make
-->

For some reason Github isn't reading the dependabot file

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/